### PR TITLE
chore: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -54,11 +54,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1657177452,
-        "narHash": "sha256-CojBqno3Zbw9/788+kCjRXXornpc4jJGC6RYvTYdVkg=",
+        "lastModified": 1661151577,
+        "narHash": "sha256-++S0TuJtuz9IpqP8rKktWyHZKpgdyrzDFUXVY07MTRI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5cbfadba693e0453f3a4090e83fbf845e18d184b",
+        "rev": "54060e816971276da05970a983487a25810c38a7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/5cbfadba693e0453f3a4090e83fbf845e18d184b' (2022-07-07)
  → 'github:nixos/nixpkgs/54060e816971276da05970a983487a25810c38a7' (2022-08-22)