### PR TITLE
clickable teaser

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -15,9 +15,11 @@ type BlogPostNode = Queries.BlogPostsQuery["allMdx"]["nodes"][0];
 const Preview = ({ node }: PreviewProps) => {
   const image = getImage(node.frontmatter.hero_image as ImageDataLike);
 
+  const to = `${node.frontmatter.date}-${node.frontmatter.slug}`;
+
   const teaser = image ? (
     <div className="w-[140px] p-[5px] shrink-0">
-      <Link to={`${node.frontmatter.date}-${node.frontmatter.slug}`}>
+      <Link to={to}>
         <GatsbyImage
           imgClassName="rounded-md"
           image={image}
@@ -34,9 +36,7 @@ const Preview = ({ node }: PreviewProps) => {
       {teaser}
       <div>
         <h2 className="text-base sm:text-lg md:text-xl">
-          <Link to={`${node.frontmatter.date}-${node.frontmatter.slug}`}>
-            {node.frontmatter.title}
-          </Link>
+          <Link to={to}>{node.frontmatter.title}</Link>
         </h2>
         <p className="text-xs md:text-sm">Posted: {node.frontmatter.date}</p>
         <p className="hidden md:block md:text-sm">{node.excerpt}</p>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -17,11 +17,13 @@ const Preview = ({ node }: PreviewProps) => {
 
   const teaser = image ? (
     <div className="w-[140px] p-[5px] shrink-0">
-      <GatsbyImage
-        imgClassName="rounded-md"
-        image={image}
-        alt={node.frontmatter.hero_image_alt}
-      />
+      <Link to={`${node.frontmatter.date}-${node.frontmatter.slug}`}>
+        <GatsbyImage
+          imgClassName="rounded-md"
+          image={image}
+          alt={node.frontmatter.hero_image_alt}
+        />
+      </Link>
     </div>
   ) : (
     <div className="w-[140px] p-[5px] shrink-0"></div>


### PR DESCRIPTION
- initialize tailwind
- deps: add typed css modules
- refactor: move some base styling around
- refactor: article styling
- refactor: styling of notebox
- refactor: remove all the styling from pre
- refactor: restyle the layout
- deps: add ramda
- chore: add some git hook for css modules
- chore: fix some nix lint
- fix: add scrollbars to code blocks
- fix: missing style for lists and inline code
- css: some more styling
- chore: some better types
- style: first session of tailwind
- style: tweak blockquote (but it is not perfect)
- finalize tailwind
- fix lints
- chore(deps): update dependency eslint to v8.43.0
- fix: build error
- adjust git-hooks
- add icons to post date and license link
- fix(deps): update gatsby monorepo
- fix the main page
- yarn-update
- feature: make teaser image a link to the article
- refactor: use a variable for link target
