### PR TITLE
add shiki transforer to get the filename into the pre

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -8,6 +8,8 @@ import mdx from "@astrojs/mdx";
 
 import tailwind from "@astrojs/tailwind";
 
+import { filenameTransformer } from "./src/scripts/filename-transformer";
+
 const tailwindIntegration = tailwind({
   applyBaseStyles: false,
 });
@@ -17,6 +19,9 @@ export default defineConfig({
   integrations: [mdx(), tailwindIntegration],
   legacy: { collections: true },
   markdown: {
-    shikiConfig: { theme: "catppuccin-mocha" },
+    shikiConfig: {
+      theme: "catppuccin-mocha",
+      transformers: [filenameTransformer()],
+    },
   },
 });

--- a/src/scripts/filename-transformer.ts
+++ b/src/scripts/filename-transformer.ts
@@ -19,8 +19,7 @@ export function filenameTransformer(): ShikiTransformer {
       if (filename) {
         code.properties.dataFilename = filename;
 
-        code.properties.class += " ";
-        code.properties.class += [
+        const titlebar_class = [
           "relative",
           "!pt-[2.5rem]",
           "before:content-[attr(data-filename)]",
@@ -43,6 +42,11 @@ export function filenameTransformer(): ShikiTransformer {
           "before:whitespace-nowrap",
           "before:overflow-x-auto",
         ].join(" ");
+
+        code.properties.class =
+          (code.properties.class ?? false)
+            ? code.properties.class + " " + titlebar_class
+            : titlebar_class;
       }
     },
   };

--- a/src/scripts/filename-transformer.ts
+++ b/src/scripts/filename-transformer.ts
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2025 Norbert Melzer
+// SPDX-FileContributor: Norbert Melzer
+//
+// SPDX-License-Identifier: MIT
+
+import type { ShikiTransformer } from "shiki";
+
+export function filenameTransformer(): ShikiTransformer {
+  const transformer: ShikiTransformer = {
+    name: "filenameTransformer",
+
+    pre(code) {
+      const meta: string = this.options.meta?.__raw || "";
+      const pattern = /(?:data-)?filename="(.*)"/;
+
+      const filename = pattern.exec(meta)?.[1] || null;
+
+      if (filename) {
+        code.properties.dataFilename = filename;
+      }
+    },
+  };
+
+  return transformer;
+}

--- a/src/scripts/filename-transformer.ts
+++ b/src/scripts/filename-transformer.ts
@@ -19,8 +19,27 @@ export function filenameTransformer(): ShikiTransformer {
       if (filename) {
         code.properties.dataFilename = filename;
 
-        code.properties.class +=
-          " relative !pt-[2rem] before:content-[attr(data-filename)] before:absolute before:top-0 before:left-0 before:w-full before:bg-crust before:border-t-2 before:border-l-2 before:border-r-2 before:border-base before:border-solid before:font-bold before:px-4 before:py-1 before:whitespace-nowrap before:overflow-x-auto";
+        code.properties.class += " ";
+        code.properties.class += [
+          "relative",
+          "!pt-[2rem]",
+          "before:content-[attr(data-filename)]",
+          "before:absolute",
+          "before:top-0",
+          "before:left-0",
+          "before:w-full",
+          "before:bg-crust",
+          "before:border-t-2",
+          "before:border-l-2",
+          "before:border-r-2",
+          "before:border-base",
+          "before:border-solid",
+          "before:font-bold",
+          "before:px-4",
+          "before:py-1",
+          "before:whitespace-nowrap",
+          "before:overflow-x-auto",
+        ].join(" ");
       }
     },
   };

--- a/src/scripts/filename-transformer.ts
+++ b/src/scripts/filename-transformer.ts
@@ -22,13 +22,16 @@ export function filenameTransformer(): ShikiTransformer {
         code.properties.class += " ";
         code.properties.class += [
           "relative",
-          "!pt-[2rem]",
+          "!pt-[2.5rem]",
           "before:content-[attr(data-filename)]",
           "before:absolute",
           "before:top-0",
           "before:left-0",
           "before:w-full",
-          "before:bg-crust",
+          "before:bg-gradient-to-b",
+          "before:from-crust",
+          "before:to-base",
+          "before:rounded-t",
           "before:border-t-2",
           "before:border-l-2",
           "before:border-r-2",

--- a/src/scripts/filename-transformer.ts
+++ b/src/scripts/filename-transformer.ts
@@ -11,7 +11,7 @@ export function filenameTransformer(): ShikiTransformer {
     name: "filenameTransformer",
 
     pre(code: Element) {
-      const meta: string = this.options.meta?.__raw || "";
+      const meta: string = this.options?.meta?.__raw || "";
       const pattern = /(?:data-)?filename="(.*?)"/;
 
       const filename = pattern.exec(meta)?.[1] || null;

--- a/src/scripts/filename-transformer.ts
+++ b/src/scripts/filename-transformer.ts
@@ -11,7 +11,7 @@ export function filenameTransformer(): ShikiTransformer {
 
     pre(code) {
       const meta: string = this.options.meta?.__raw || "";
-      const pattern = /(?:data-)?filename="(.*)"/;
+      const pattern = /(?:data-)?filename="(.*?)"/;
 
       const filename = pattern.exec(meta)?.[1] || null;
 

--- a/src/scripts/filename-transformer.ts
+++ b/src/scripts/filename-transformer.ts
@@ -17,6 +17,9 @@ export function filenameTransformer(): ShikiTransformer {
 
       if (filename) {
         code.properties.dataFilename = filename;
+
+        code.properties.class +=
+          " relative !pt-[2rem] before:content-[attr(data-filename)] before:absolute before:top-0 before:left-0 before:w-full before:bg-crust before:border-t-2 before:border-l-2 before:border-r-2 before:border-base before:border-solid before:font-bold before:px-4 before:py-1 before:whitespace-nowrap before:overflow-x-auto";
       }
     },
   };

--- a/src/scripts/filename-transformer.ts
+++ b/src/scripts/filename-transformer.ts
@@ -4,12 +4,13 @@
 // SPDX-License-Identifier: MIT
 
 import type { ShikiTransformer } from "shiki";
+import type { Element } from "hast";
 
 export function filenameTransformer(): ShikiTransformer {
   const transformer: ShikiTransformer = {
     name: "filenameTransformer",
 
-    pre(code) {
+    pre(code: Element) {
       const meta: string = this.options.meta?.__raw || "";
       const pattern = /(?:data-)?filename="(.*?)"/;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced markdown processing now extracts and displays filename information embedded in code block metadata.
	- Improved transformation capabilities within markdown content to showcase contextual code metadata without altering existing theme settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->